### PR TITLE
fix use of qw() without parentheses in for loop

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,7 @@ requires_external_cc;
 requires 'parent';
 configure_requires 'ExtUtils::Depends' => 0.302; #minimum version that works on Win32+gcc
 
-foreach my $mod qw(B::Hooks::OP::Check::EntersubForCV) {
+foreach my $mod ( qw(B::Hooks::OP::Check::EntersubForCV) ) {
 	configure_requires $mod;
 	build_requires $mod;
 	requires $mod;


### PR DESCRIPTION
this was removed in perl 5.18:

```
http://search.cpan.org/dist/perl-5.18.0/pod/perldelta.pod#qw%28...%29_can_no_longer_be_used_as_parentheses
```
